### PR TITLE
feat(parser): Implement XmlStyleToolCallParser for XML-style tool calls

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,8 @@
   },
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "files.associations": {
+    "string": "cpp"
   }
 }

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -638,11 +638,7 @@ export async function loadCliConfig(
         : argv.openaiLogging) ?? false,
     systemPromptMappings: (settings.systemPromptMappings ?? [
       {
-        baseUrls: [
-          'https://dashscope.aliyuncs.com/compatible-mode/v1/',
-          'https://dashscope-intl.aliyuncs.com/compatible-mode/v1/',
-        ],
-        modelNames: ['qwen3-coder-plus'],
+        // Apply qwen3_coder template to all models by omitting baseUrls and modelNames
         template:
           'SYSTEM_TEMPLATE:{"name":"qwen3_coder","params":{"is_git_repository":{RUNTIME_VARS_IS_GIT_REPO},"sandbox":"{RUNTIME_VARS_SANDBOX}"}}',
       },

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -2911,17 +2911,28 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
                 settings.merged.ui?.hideBanner || config.getScreenReader()
               ) && <Header version={version} nightly={nightly} />}
             </Box>,
-            ...history.map((h) => (
-              <HistoryItemDisplay
-                terminalWidth={mainAreaWidth}
-                availableTerminalHeight={staticAreaMaxItemHeight}
-                key={h.id}
-                item={h}
-                isPending={false}
-                config={config}
-                commands={slashCommands}
-              />
-            )),
+            ...history.map((h, index) => {
+              // Find the first assistant message in the history
+              const firstAssistantMessageIndex = history.findIndex(
+                (item) => item.type === 'gemini' || item.type === 'gemini_content'
+              );
+              const isFirstAssistantMessage = 
+                (h.type === 'gemini' || h.type === 'gemini_content') && 
+                index === firstAssistantMessageIndex;
+
+              return (
+                <HistoryItemDisplay
+                  terminalWidth={mainAreaWidth}
+                  availableTerminalHeight={staticAreaMaxItemHeight}
+                  key={h.id}
+                  item={h}
+                  isPending={false}
+                  config={config}
+                  commands={slashCommands}
+                  isFirstAssistantMessage={isFirstAssistantMessage}
+                />
+              );
+            }),
           ]}
         >
           {(item) => item}

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -34,6 +34,7 @@ interface HistoryItemDisplayProps {
   config: Config;
   isFocused?: boolean;
   commands?: readonly SlashCommand[];
+  isFirstAssistantMessage?: boolean;
 }
 
 const HistoryItemDisplayComponent: React.FC<HistoryItemDisplayProps> = ({
@@ -44,25 +45,28 @@ const HistoryItemDisplayComponent: React.FC<HistoryItemDisplayProps> = ({
   config,
   commands,
   isFocused = true,
+  isFirstAssistantMessage = false,
 }) => (
   <Box flexDirection="column" key={item.id}>
     {/* Render standard message types */}
     {item.type === 'user' && <UserMessage text={item.text} />}
     {item.type === 'user_shell' && <UserShellMessage text={item.text} />}
-    {item.type === 'gemini' && (
+    {item.type === 'gemini' && item.text.trim() && (
       <GeminiMessage
         text={item.text}
         isPending={isPending}
         availableTerminalHeight={availableTerminalHeight}
         terminalWidth={terminalWidth}
+        isFirstAssistantMessage={isFirstAssistantMessage}
       />
     )}
-    {item.type === 'gemini_content' && (
+    {item.type === 'gemini_content' && item.text.trim() && (
       <GeminiMessageContent
         text={item.text}
         isPending={isPending}
         availableTerminalHeight={availableTerminalHeight}
         terminalWidth={terminalWidth}
+        isFirstAssistantMessage={isFirstAssistantMessage}
       />
     )}
     {item.type === 'info' && <InfoMessage text={item.text} />}

--- a/packages/cli/src/ui/components/messages/GeminiMessage.tsx
+++ b/packages/cli/src/ui/components/messages/GeminiMessage.tsx
@@ -15,6 +15,7 @@ interface GeminiMessageProps {
   isPending: boolean;
   availableTerminalHeight?: number;
   terminalWidth: number;
+  isFirstAssistantMessage?: boolean;
 }
 
 export const GeminiMessage: React.FC<GeminiMessageProps> = ({
@@ -22,12 +23,16 @@ export const GeminiMessage: React.FC<GeminiMessageProps> = ({
   isPending,
   availableTerminalHeight,
   terminalWidth,
+  isFirstAssistantMessage = false,
 }) => {
   const prefix = '✦ ';
   const prefixWidth = prefix.length;
 
   return (
-    <Box flexDirection="row" marginLeft={1}>
+    <Box 
+      flexDirection="row" 
+      marginTop={isFirstAssistantMessage ? 0 : 1}
+    >
       <Box width={prefixWidth}>
         <Text
           color={Colors.AccentPurple}

--- a/packages/cli/src/ui/components/messages/GeminiMessageContent.tsx
+++ b/packages/cli/src/ui/components/messages/GeminiMessageContent.tsx
@@ -13,6 +13,7 @@ interface GeminiMessageContentProps {
   isPending: boolean;
   availableTerminalHeight?: number;
   terminalWidth: number;
+  isFirstAssistantMessage?: boolean;
 }
 
 /*
@@ -26,18 +27,27 @@ export const GeminiMessageContent: React.FC<GeminiMessageContentProps> = ({
   isPending,
   availableTerminalHeight,
   terminalWidth,
+  isFirstAssistantMessage = false,
 }) => {
-  const originalPrefix = '✦ ';
-  const prefixWidth = originalPrefix.length;
+  const prefix = '✦ ';
+  const prefixWidth = prefix.length;
 
   return (
-    <Box flexDirection="column" paddingLeft={prefixWidth}>
-      <MarkdownDisplay
-        text={text}
-        isPending={isPending}
-        availableTerminalHeight={availableTerminalHeight}
-        terminalWidth={terminalWidth}
-      />
+    <Box 
+      flexDirection="row" 
+      marginTop={isFirstAssistantMessage ? 0 : 1}
+    >
+      <Box width={prefixWidth}>
+        {/* Empty space to align with the prefix from GeminiMessage */}
+      </Box>
+      <Box flexGrow={1} flexDirection="column">
+        <MarkdownDisplay
+          text={text}
+          isPending={isPending}
+          availableTerminalHeight={availableTerminalHeight}
+          terminalWidth={terminalWidth}
+        />
+      </Box>
     </Box>
   );
 };

--- a/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolConfirmationMessage.tsx
@@ -92,7 +92,7 @@ export const ToolConfirmationMessage: React.FC<
     ];
 
     return (
-      <Box flexDirection="column">
+      <Box flexDirection="column" paddingLeft={1}>
         <Box>
           <Text wrap="truncate">Do you want to proceed?</Text>
         </Box>
@@ -340,7 +340,7 @@ export const ToolConfirmationMessage: React.FC<
   }
 
   return (
-    <Box flexDirection="column" padding={1} width={childWidth}>
+    <Box flexDirection="column" padding={1} paddingLeft={2} width={childWidth}>
       {/* Body Content (Diff Renderer or Command Info) */}
       {/* No separate context display here anymore for edits */}
       <Box flexGrow={1} flexShrink={1} overflow="hidden" marginBottom={1}>

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -11,11 +11,7 @@ import type { IndividualToolCallDisplay } from '../../types.js';
 import { ToolCallStatus } from '../../types.js';
 import { ToolMessage } from './ToolMessage.js';
 import { ToolConfirmationMessage } from './ToolConfirmationMessage.js';
-import { Colors } from '../../colors.js';
 import type { Config } from '@kolosal-ai/kolosal-ai-core';
-import { SHELL_COMMAND_NAME } from '../../constants.js';
-import { LeftBorderPanel } from '../shared/LeftBorderPanel.js';
-import { getDimmerPanelBackgroundColor } from '../shared/panelStyles.js';
 
 interface ToolGroupMessageProps {
   groupId: number;
@@ -34,13 +30,6 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
   config,
   isFocused = true,
 }) => {
-  const hasPending = !toolCalls.every(
-    (t) => t.status === ToolCallStatus.Success,
-  );
-  const isShellCommand = toolCalls.some((t) => t.name === SHELL_COMMAND_NAME);
-  const borderColor =
-    hasPending || isShellCommand ? Colors.AccentYellow : Colors.Gray;
-
   const staticHeight = /* border */ 2 + /* marginBottom */ 1;
   // This is a bit of a magic number, but it accounts for the border and
   // marginLeft.
@@ -71,17 +60,15 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
     : undefined;
 
   return (
-    <LeftBorderPanel
-      accentColor={borderColor}
-      backgroundColor={getDimmerPanelBackgroundColor()}
+    <Box
+      flexDirection="column"
       width="100%"
-      marginLeft={1}
+      marginLeft={0}
       marginTop={1}
-      marginBottom={1}
-      contentProps={{
-        flexDirection: 'column',
-        padding: 1,
-      }}
+      paddingTop={1}
+      paddingLeft={0}
+      paddingRight={1}
+      paddingBottom={0}
     >
       {toolCalls.map((tool) => {
         const isConfirming = toolAwaitingApproval?.callId === tool.callId;
@@ -124,6 +111,6 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
           </Box>
         );
       })}
-    </LeftBorderPanel>
+    </Box>
   );
 };

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -23,7 +23,6 @@ import type {
 } from '@kolosal-ai/kolosal-ai-core';
 import { AgentExecutionDisplay } from '../subagents/index.js';
 import { PlanSummaryDisplay } from '../PlanSummaryDisplay.js';
-import { LeftBorderPanel } from '../shared/LeftBorderPanel.js';
 
 const STATIC_HEIGHT = 1;
 const RESERVED_LINE_COUNT = 5; // for tool name, status, padding etc.
@@ -239,19 +238,8 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
   // Use the custom hook to determine the display type
   const displayRenderer = useResultDisplayRenderer(resultDisplay);
 
-  const borderColor = Colors.AccentBlue;
-
   return (
-    <LeftBorderPanel
-      accentColor={borderColor}
-      ruleMarginRight={1}
-      contentProps={{
-        paddingLeft: 1,
-        paddingTop: 0,
-        paddingBottom: 0,
-        flexDirection: 'column',
-      }}
-    >
+    <Box flexDirection="column">
       <Box minHeight={1}>
         <ToolStatusIndicator status={status} />
         <ToolInfo
@@ -263,7 +251,7 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
         {emphasis === 'high' && <TrailingIndicator />}
       </Box>
       {displayRenderer.type !== 'none' && (
-        <Box paddingLeft={STATUS_INDICATOR_WIDTH} width="100%" marginTop={1}>
+        <Box paddingLeft={STATUS_INDICATOR_WIDTH - 1} width="100%" marginTop={1}>
           <Box flexDirection="column">
             {displayRenderer.type === 'todo' && (
               <TodoResultRenderer data={displayRenderer.data} />
@@ -301,7 +289,7 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
           </Box>
         </Box>
       )}
-    </LeftBorderPanel>
+    </Box>
   );
 };
 
@@ -312,7 +300,7 @@ type ToolStatusIndicatorProps = {
 const ToolStatusIndicator: React.FC<ToolStatusIndicatorProps> = ({
   status,
 }) => (
-  <Box minWidth={STATUS_INDICATOR_WIDTH}>
+  <Box minWidth={2}>
     {status === ToolCallStatus.Pending && (
       <Text color={Colors.AccentGreen}>{TOOL_STATUS.PENDING}</Text>
     )}

--- a/packages/cli/src/ui/components/shared/LeftBorderPanel.tsx
+++ b/packages/cli/src/ui/components/shared/LeftBorderPanel.tsx
@@ -79,9 +79,8 @@ export function LeftBorderPanel({
       <Box
         ref={contentRef}
         flexDirection={contentFlexDirection ?? 'column'}
-  flexGrow={contentFlexGrow ?? 1}
-  minWidth={0}
-        backgroundColor={backgroundColor}
+        flexGrow={contentFlexGrow ?? 1}
+        minWidth={0}
         minHeight={0}
         {...restContentProps}
       >

--- a/packages/core/XML_TOOL_CALL_FORMAT.md
+++ b/packages/core/XML_TOOL_CALL_FORMAT.md
@@ -1,0 +1,73 @@
+# XML-Style Tool Call Format Support
+
+This document demonstrates the new XML-style tool call format support that has been added to the streaming tool call parser.
+
+## Format Specification
+
+The XML-style tool call format uses the following delimiters:
+
+- `<|tool_calls_section_begin|>` - Marks the beginning of a tool calls section
+- `<|tool_call_begin|>` - Marks the beginning of an individual tool call
+- `<|tool_call_argument_begin|>` - Marks the beginning of tool call arguments
+- `<|tool_call_end|>` - Marks the end of an individual tool call
+- `<|tool_calls_section_end|>` - Marks the end of a tool calls section
+
+## Examples
+
+### Single Tool Call
+
+```
+<|tool_calls_section_begin|><|tool_call_begin|>functions.list_directory:0<|tool_call_argument_begin|>{"path": "/Users/rbisri/Documents/test-kolosal-code/sentiment-classification"}<|tool_call_end|><|tool_calls_section_end|>
+```
+
+This will be parsed as:
+- Function name: `list_directory`
+- ID: `0`
+- Arguments: `{"path": "/Users/rbisri/Documents/test-kolosal-code/sentiment-classification"}`
+
+### Multiple Tool Calls
+
+```
+<|tool_calls_section_begin|><|tool_call_begin|>functions.list_directory:0<|tool_call_argument_begin|>{"path": "/path1"}<|tool_call_end|><|tool_call_begin|>functions.read_file:1<|tool_call_argument_begin|>{"filePath": "/path2"}<|tool_call_end|><|tool_calls_section_end|>
+```
+
+This will be parsed as two separate function calls:
+1. `list_directory` with ID `0` and arguments `{"path": "/path1"}`
+2. `read_file` with ID `1` and arguments `{"filePath": "/path2"}`
+
+### Tool Call Without ID
+
+```
+<|tool_calls_section_begin|><|tool_call_begin|>functions.read_file<|tool_call_argument_begin|>{"filePath": "/path/to/file"}<|tool_call_end|><|tool_calls_section_end|>
+```
+
+The ID is optional. If not provided, only the function name and arguments will be parsed.
+
+## Function Name Parsing
+
+The function specification supports namespaced functions:
+- `functions.list_directory:0` → function name: `list_directory`, ID: `0`
+- `system.functions.nested.tool:1` → function name: `tool`, ID: `1`
+- `simple_func:2` → function name: `simple_func`, ID: `2`
+
+The parser extracts the last part after the final dot as the function name.
+
+## Streaming Support
+
+The parser supports streaming across multiple chunks. Tool calls can be fragmented across multiple content chunks and will be properly assembled.
+
+## Integration
+
+The XML-style parser is integrated into the `OpenAIContentConverter` and will automatically detect XML-style tool call markers in content. It works alongside the existing OpenAI JSON-style tool call format, so both formats are supported simultaneously.
+
+## Error Handling
+
+The parser handles various error cases:
+- Empty tool call arguments result in an error
+- Invalid JSON in arguments results in an error
+- Missing function names result in an error
+- Malformed XML structure is handled gracefully
+
+## Usage
+
+The XML-style tool call parser is automatically used when XML-style markers are detected in streaming content. No additional configuration is required.

--- a/packages/core/src/core/openaiContentGenerator/converter.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { OpenAIContentConverter } from './converter.js';
 import type { StreamingToolCallParser } from './streamingToolCallParser.js';
+import type { GenerateContentParameters } from '@google/genai';
 
 describe('OpenAIContentConverter', () => {
   let converter: OpenAIContentConverter;
@@ -68,4 +69,340 @@ describe('OpenAIContentConverter', () => {
       expect(parser.getBuffer(0)).toBe('');
     });
   });
+
+  describe('streaming tool call text removal', () => {
+    it('should buffer text content during streaming and emit clean text when complete', () => {
+      // Simulate streaming chunks that contain inline tool calls
+      // This simulates the user's scenario where tool call markers were leaking through
+      
+      // Chunk 1: Start of text + beginning of tool call
+      const chunk1 = {
+        choices: [{
+          delta: {
+            content: '✦ I\'ll create a simple snake game in Python. Let me start by planning this task.functions.todo_write:0{"todos": [{"id": "1", "content": "Create main file"'
+          }
+        }]
+      };
+      
+      // Chunk 2: Middle of tool call JSON
+      const chunk2 = {
+        choices: [{
+          delta: {
+            content: ', "status": "pending"}]}I\'ll create a simple snake game in Python. Let me start by planning this task.'
+          }
+        }]
+      };
+      
+      // Chunk 3: Stream completion
+      const chunk3 = {
+        choices: [{
+          delta: {
+            content: ''
+          },
+          finish_reason: 'stop'
+        }]
+      };
+
+      // Process chunks
+      const result1 = converter.convertOpenAIChunkToGemini(chunk1 as any);
+      const result2 = converter.convertOpenAIChunkToGemini(chunk2 as any);
+      const result3 = converter.convertOpenAIChunkToGemini(chunk3 as any);
+
+      // During streaming (chunks 1 and 2), no text should be emitted to prevent tool call leakage
+      expect(result1.candidates?.[0]?.content?.parts?.some(part => 'text' in part)).toBe(false);
+      expect(result2.candidates?.[0]?.content?.parts?.some(part => 'text' in part)).toBe(false);
+
+      // When stream completes (chunk 3), should emit cleaned text and tool calls
+      const finalParts = result3.candidates?.[0]?.content?.parts || [];
+      const textParts = finalParts.filter(part => 'text' in part);
+      const functionCalls = finalParts.filter(part => 'functionCall' in part);
+
+      // Should have found the tool call
+      expect(functionCalls).toHaveLength(1);
+      expect(functionCalls[0]).toMatchObject({
+        functionCall: {
+          name: 'todo_write',
+          args: {
+            todos: [{ id: "1", content: "Create main file", status: "pending" }]
+          }
+        }
+      });
+
+      // Should have cleaned text content (without tool call markers)
+      expect(textParts).toHaveLength(1);
+      const cleanedText = (textParts[0] as any).text;
+      expect(cleanedText).toContain('✦ I\'ll create a simple snake game in Python');
+      expect(cleanedText).not.toContain('functions.todo_write:0{');
+      expect(cleanedText).not.toContain('{"todos":');
+    });
+  });
+
+  describe('malformed array content handling', () => {
+    it('should handle array of parts as content (422 error fix)', () => {
+      // This tests the fix for the 422 API error where conversation history
+      // contains arrays of parts instead of proper Content objects
+      const request = {
+        contents: [
+          // Normal user message
+          {
+            role: 'user',
+            parts: [{ text: 'Hello' }]
+          },
+          // Normal assistant response with tool call
+          {
+            role: 'model',
+            parts: [
+              { text: 'I will help you.' },
+              {
+                functionCall: {
+                  id: 'call_123',
+                  name: 'test_function',
+                  args: { param: 'value' }
+                }
+              }
+            ]
+          },
+          // Malformed function response - array instead of Content object
+          // This is what causes the 422 error
+          [
+            {
+              functionResponse: {
+                id: 'call_123',
+                name: 'test_function',
+                response: { result: 'success' }
+              }
+            }
+          ]
+        ]
+      };
+
+      const messages = converter.convertGeminiRequestToOpenAI(request as any);
+
+      // Should have 3 messages: user, assistant with tool call, and tool response
+      expect(messages).toHaveLength(3);
+      
+      // First message: user
+      expect(messages[0]).toMatchObject({
+        role: 'user'
+      });
+      // Content should be either string or array with text
+      const userContent = (messages[0] as any).content;
+      const textContent = typeof userContent === 'string' ? userContent : 
+        userContent.find((part: any) => part.type === 'text')?.text;
+      expect(textContent).toBe('Hello');
+
+      // Second message: assistant with tool call
+      expect(messages[1]).toMatchObject({
+        role: 'assistant',
+        content: 'I will help you.',
+        tool_calls: [{
+          id: 'call_123',
+          type: 'function',
+          function: {
+            name: 'test_function',
+            arguments: '{"param":"value"}'
+          }
+        }]
+      });
+
+      // Third message: tool response (from malformed array)
+      expect(messages[2]).toMatchObject({
+        role: 'tool',
+        tool_call_id: 'call_123',
+        content: '{"result":"success"}'
+      });
+    });
+
+    it('should handle bare Part[] arrays in conversation history', () => {
+      // This simulates the malformed case from the error log where a Part[] array
+      // is stored directly in contents instead of being wrapped in a Content object
+      const malformedRequest: GenerateContentParameters = {
+        model: 'test-model',
+        contents: [
+          {
+            role: 'user',
+            parts: [{ text: 'compare for loop speed in python and c++' }]
+          },
+          {
+            role: 'model',
+            parts: [
+              { text: 'I will create a comparison.' },
+              {
+                functionCall: {
+                  id: '0',
+                  name: 'todo_write',
+                  args: { todos: [{ id: '1', content: 'Create test', status: 'pending' }] }
+                }
+              }
+            ]
+          },
+          [
+            {
+              functionResponse: {
+                id: '0',
+                name: 'todo_write',
+                response: { output: '{"success":true}' }
+              }
+            }
+          ] as any, // Malformed: bare Part[] instead of Content
+        ]
+      };
+
+      const result = converter.convertGeminiRequestToOpenAI(malformedRequest);
+      
+      // Should have 3 messages: user + assistant with tool_calls + tool response
+      expect(result.length).toBeGreaterThanOrEqual(3);
+      
+      // Find the tool message
+      const toolMessage = result.find(m => m.role === 'tool');
+      expect(toolMessage).toBeDefined();
+      expect(toolMessage).toMatchObject({
+        role: 'tool',
+        tool_call_id: '0'
+      });
+    });
+
+    it('should remap duplicate tool call ids to keep OpenAI payload valid', () => {
+      const request: GenerateContentParameters = {
+        model: 'test-model',
+        contents: [
+          {
+            role: 'user',
+            parts: [{ text: 'compare for loop speed in python and c++' }],
+          },
+          {
+            role: 'model',
+            parts: [
+              { text: 'Planning benchmarks.' },
+              {
+                functionCall: {
+                  id: '0',
+                  name: 'todo_write',
+                  args: { todos: [{ id: '1', content: 'python script', status: 'pending' }] },
+                },
+              },
+            ],
+          },
+          {
+            role: 'user',
+            parts: [
+              {
+                functionResponse: {
+                  id: '0',
+                  name: 'todo_write',
+                  response: { output: '{"success":true}' },
+                },
+              },
+            ],
+          },
+          {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  id: '0',
+                  name: 'todo_write',
+                  args: {
+                    todos: [
+                      { id: '1', content: 'python script', status: 'in_progress' },
+                      { id: '2', content: 'c++ benchmark', status: 'pending' },
+                    ],
+                  },
+                },
+              },
+            ],
+          },
+          [
+            {
+              functionResponse: {
+                id: '0',
+                name: 'todo_write',
+                response: {
+                  output:
+                    '{"success":true,"todos":[{"id":"1","status":"in_progress"},{"id":"2","status":"pending"}]}',
+                },
+              },
+            },
+          ] as any,
+        ],
+      };
+
+      const messages = converter.convertGeminiRequestToOpenAI(request);
+      const assistantMessages = messages.filter((m) => m.role === 'assistant');
+      const toolMessages = messages.filter((m) => m.role === 'tool');
+
+      expect(assistantMessages).toHaveLength(2);
+      expect(assistantMessages[0]).toMatchObject({
+        role: 'assistant',
+        tool_calls: [
+          {
+            id: '0',
+            function: {
+              name: 'todo_write',
+            },
+          },
+        ],
+      });
+      expect(assistantMessages[1]).toMatchObject({
+        role: 'assistant',
+        tool_calls: [
+          {
+            id: '0__1',
+            function: {
+              name: 'todo_write',
+            },
+          },
+        ],
+      });
+
+      expect(toolMessages).toHaveLength(2);
+      expect(toolMessages.map((m) => (m as any).tool_call_id)).toEqual(['0', '0__1']);
+    });
+
+      it('should deduplicate sequential text segments around tool calls', () => {
+        const request: GenerateContentParameters = {
+          model: 'test-model',
+          contents: [
+            {
+              role: 'model',
+              parts: [
+                {
+                  text: 'Repeated text before call.'
+                },
+                {
+                  functionCall: {
+                    id: '123',
+                    name: 'test_function',
+                    args: { foo: 'bar' }
+                  }
+                },
+                {
+                  text: 'Repeated text before call.'
+                }
+              ]
+            },
+            {
+              role: 'user',
+              parts: [
+                {
+                  functionResponse: {
+                    id: '123',
+                    name: 'test_function',
+                    response: { output: 'ok' }
+                  }
+                }
+              ]
+            }
+          ]
+        };
+
+        const messages = converter.convertGeminiRequestToOpenAI(request);
+        const assistantMessage = messages.find((m) => m.role === 'assistant');
+
+        expect(assistantMessage).toBeDefined();
+        expect(assistantMessage?.content).toBe('Repeated text before call.');
+      });
+  });
 });
+
+

--- a/packages/core/src/core/openaiContentGenerator/xmlStyleToolCallParser.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/xmlStyleToolCallParser.test.ts
@@ -1,0 +1,569 @@
+/**
+ * @license
+ * Copyright 2025 Kolosal
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { XmlStyleToolCallParser } from './xmlStyleToolCallParser.js';
+
+describe('XmlStyleToolCallParser', () => {
+  let parser: XmlStyleToolCallParser;
+
+  beforeEach(() => {
+    parser = new XmlStyleToolCallParser();
+  });
+
+  describe('Basic functionality', () => {
+    it('should initialize with empty state', () => {
+      expect(parser.getCompletedToolCalls()).toEqual([]);
+    });
+
+    it('should handle complete tool call in single chunk', () => {
+      const content = '<|tool_calls_section_begin|><|tool_call_begin|>functions.list_directory:0<|tool_call_argument_begin|>{"path": "/Users/rbisri/Documents/test-kolosal-code/sentiment-classification"}<|tool_call_end|><|tool_calls_section_end|>';
+      
+      const result = parser.addChunk(content);
+      
+      expect(result.complete).toBe(true);
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls![0]).toEqual({
+        id: '0',
+        name: 'list_directory',
+        args: { path: '/Users/rbisri/Documents/test-kolosal-code/sentiment-classification' }
+      });
+    });
+
+    it('should handle tool call without ID', () => {
+      const content = '<|tool_calls_section_begin|><|tool_call_begin|>functions.read_file<|tool_call_argument_begin|>{"filePath": "/path/to/file"}<|tool_call_end|><|tool_calls_section_end|>';
+      
+      const result = parser.addChunk(content);
+      
+      expect(result.complete).toBe(true);
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls![0]).toEqual({
+        name: 'read_file',
+        args: { filePath: '/path/to/file' }
+      });
+    });
+
+    it('should handle multiple tool calls in one section', () => {
+      const content = '<|tool_calls_section_begin|><|tool_call_begin|>functions.list_directory:0<|tool_call_argument_begin|>{"path": "/path1"}<|tool_call_end|><|tool_call_begin|>functions.read_file:1<|tool_call_argument_begin|>{"filePath": "/path2"}<|tool_call_end|><|tool_calls_section_end|>';
+      
+      const result = parser.addChunk(content);
+      
+      expect(result.complete).toBe(true);
+      expect(result.toolCalls).toHaveLength(2);
+      expect(result.toolCalls![0]).toEqual({
+        id: '0',
+        name: 'list_directory',
+        args: { path: '/path1' }
+      });
+      expect(result.toolCalls![1]).toEqual({
+        id: '1',
+        name: 'read_file',
+        args: { filePath: '/path2' }
+      });
+    });
+  });
+
+  describe('Streaming functionality', () => {
+    it('should accumulate chunks until complete', () => {
+      let result = parser.addChunk('<|tool_calls_section_begin|><|tool_call_begin|>functions.list_directory:0');
+      expect(result.complete).toBe(false);
+
+      result = parser.addChunk('<|tool_call_argument_begin|>{"path": "/test"}');
+      expect(result.complete).toBe(false);
+
+      result = parser.addChunk('<|tool_call_end|><|tool_calls_section_end|>');
+      expect(result.complete).toBe(true);
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls![0]).toEqual({
+        id: '0',
+        name: 'list_directory',
+        args: { path: '/test' }
+      });
+    });
+
+    it('should handle fragmented delimiters', () => {
+      let result = parser.addChunk('<|tool_calls_section_');
+      expect(result.complete).toBe(false);
+
+      result = parser.addChunk('begin|><|tool_call_begin|>functions.test:1<|tool_call_argument_');
+      expect(result.complete).toBe(false);
+
+      result = parser.addChunk('begin|>{"key": "value"}<|tool_call_end|><|tool_calls_section_end|>');
+      expect(result.complete).toBe(true);
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls![0]).toEqual({
+        id: '1',
+        name: 'test',
+        args: { key: 'value' }
+      });
+    });
+
+    it('should handle mixed content with tool calls', () => {
+      let result = parser.addChunk('Some regular text before ');
+      expect(result.complete).toBe(false);
+
+      result = parser.addChunk('<|tool_calls_section_begin|><|tool_call_begin|>functions.my_func:2<|tool_call_argument_begin|>{}');
+      expect(result.complete).toBe(false);
+
+      result = parser.addChunk('<|tool_call_end|><|tool_calls_section_end|> and some text after');
+      expect(result.complete).toBe(true);
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls![0]).toEqual({
+        id: '2',
+        name: 'my_func',
+        args: {}
+      });
+      // Should extract and return text content that's not part of tool calls
+      expect(result.textContent).toBe('Some regular text before  and some text after');
+    });
+
+    it('should extract text content from XML tool calls', () => {
+      const content = 'Let me check the current directory<|tool_calls_section_begin|><|tool_call_begin|>functions.list_directory:0<|tool_call_argument_begin|>{"path": "."}<|tool_call_end|><|tool_calls_section_end|>';
+      
+      const result = parser.addChunk(content);
+      
+      expect(result.complete).toBe(true);
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls![0]).toEqual({
+        id: '0',
+        name: 'list_directory',
+        args: { path: '.' }
+      });
+      expect(result.textContent).toBe('Let me check the current directory');
+    });
+
+    it('should extract text content before and after tool calls', () => {
+      const content = 'I need to read the file<|tool_calls_section_begin|><|tool_call_begin|>functions.read_file:1<|tool_call_argument_begin|>{"filePath": "/path/file.txt"}<|tool_call_end|><|tool_calls_section_end|>to understand the issue better.';
+      
+      const result = parser.addChunk(content);
+      
+      expect(result.complete).toBe(true);
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls![0]).toEqual({
+        id: '1',
+        name: 'read_file',
+        args: { filePath: '/path/file.txt' }
+      });
+      expect(result.textContent).toBe('I need to read the fileto understand the issue better.');
+    });
+  });
+
+  describe('Error handling', () => {
+    it('should handle invalid JSON in arguments', () => {
+      const content = '<|tool_calls_section_begin|><|tool_call_begin|>functions.test:0<|tool_call_argument_begin|>{invalid json<|tool_call_end|><|tool_calls_section_end|>';
+      
+      const result = parser.addChunk(content);
+      
+      expect(result.complete).toBe(false);
+      expect(result.error).toBeDefined();
+      expect(result.error!).toContain('Failed to parse tool call arguments');
+    });
+
+    it('should handle missing function name', () => {
+      const content = '<|tool_calls_section_begin|><|tool_call_begin|>:0<|tool_call_argument_begin|>{"key": "value"}<|tool_call_end|><|tool_calls_section_end|>';
+      
+      const result = parser.addChunk(content);
+      
+      expect(result.complete).toBe(false);
+      expect(result.error).toBeDefined();
+      expect(result.error!).toContain('Tool call missing function name');
+    });
+  });
+
+  describe('Function name parsing', () => {
+    it('should extract function name from path', () => {
+      const content = '<|tool_calls_section_begin|><|tool_call_begin|>functions.my_tool_name:0<|tool_call_argument_begin|>{}<|tool_call_end|><|tool_calls_section_end|>';
+      
+      const result = parser.addChunk(content);
+      
+      expect(result.complete).toBe(true);
+      expect(result.toolCalls![0].name).toBe('my_tool_name');
+    });
+
+    it('should handle nested namespaces', () => {
+      const content = '<|tool_calls_section_begin|><|tool_call_begin|>system.functions.nested.tool:0<|tool_call_argument_begin|>{}<|tool_call_end|><|tool_calls_section_end|>';
+      
+      const result = parser.addChunk(content);
+      
+      expect(result.complete).toBe(true);
+      expect(result.toolCalls![0].name).toBe('tool');
+    });
+
+    it('should handle simple function name without namespace', () => {
+      const content = '<|tool_calls_section_begin|><|tool_call_begin|>simple_func:0<|tool_call_argument_begin|>{}<|tool_call_end|><|tool_calls_section_end|>';
+      
+      const result = parser.addChunk(content);
+      
+      expect(result.complete).toBe(true);
+      expect(result.toolCalls![0].name).toBe('simple_func');
+    });
+  });
+
+  describe('Reset functionality', () => {
+    it('should reset parser state', () => {
+      parser.addChunk('<|tool_calls_section_begin|><|tool_call_begin|>functions.test:0<|tool_call_argument_begin|>{"key": "value"}');
+      
+      parser.reset();
+      
+      expect(parser.getCompletedToolCalls()).toEqual([]);
+      
+      const result = parser.addChunk('<|tool_calls_section_begin|><|tool_call_begin|>functions.other:1<|tool_call_argument_begin|>{"other": "data"}<|tool_call_end|><|tool_calls_section_end|>');
+      expect(result.complete).toBe(true);
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls![0].name).toBe('other');
+    });
+  });
+
+  describe('Static utility methods', () => {
+    it('should detect XML tool call markers', () => {
+      expect(XmlStyleToolCallParser.containsXmlToolCallMarkers('<|tool_calls_section_begin|>')).toBe(true);
+      expect(XmlStyleToolCallParser.containsXmlToolCallMarkers('<|tool_call_begin|>')).toBe(true);
+      expect(XmlStyleToolCallParser.containsXmlToolCallMarkers('regular text')).toBe(false);
+      expect(XmlStyleToolCallParser.containsXmlToolCallMarkers('some <|tool_calls_section_begin|> content')).toBe(true);
+    });
+
+    it('should detect basic tool call patterns without XML markers', () => {
+      // Test the basic pattern detection
+      expect(XmlStyleToolCallParser.containsXmlToolCallMarkers('functions.todo_write:0{"todos": []}')).toBe(true);
+      expect(XmlStyleToolCallParser.containsXmlToolCallMarkers('simple_function:123{"arg": "value"}')).toBe(true);
+      expect(XmlStyleToolCallParser.containsXmlToolCallMarkers('functions.complex_name:0{"complex": {"nested": "data"}}')).toBe(true);
+      
+      // Test embedded patterns (tool calls within text)
+      expect(XmlStyleToolCallParser.containsXmlToolCallMarkers('Some text before:functions.test:1{"arg": "value"}')).toBe(true);
+      expect(XmlStyleToolCallParser.containsXmlToolCallMarkers('Let me create a file:functions.write_file:0{"path": "/test"}')).toBe(true);
+      
+      // Should not match invalid patterns
+      expect(XmlStyleToolCallParser.containsXmlToolCallMarkers('not_a_function {"arg": "value"}')).toBe(false);
+      expect(XmlStyleToolCallParser.containsXmlToolCallMarkers('functions.name:id without json')).toBe(false);
+      expect(XmlStyleToolCallParser.containsXmlToolCallMarkers('just some regular text')).toBe(false);
+    });
+
+    it('should detect markdown-style tool call patterns', () => {
+      // Test markdown-style tool call detection
+      expect(XmlStyleToolCallParser.containsXmlToolCallMarkers('[tool_call: read_file]')).toBe(true);
+      expect(XmlStyleToolCallParser.containsXmlToolCallMarkers('[tool_call: write_file]')).toBe(true);
+      expect(XmlStyleToolCallParser.containsXmlToolCallMarkers('Some text [tool_call: test_function]')).toBe(true);
+      expect(XmlStyleToolCallParser.containsXmlToolCallMarkers('Content with <｜tool▁call▁end｜> marker')).toBe(true);
+      
+      // Should not match invalid markdown patterns
+      expect(XmlStyleToolCallParser.containsXmlToolCallMarkers('[not_tool_call: something]')).toBe(false);
+      expect(XmlStyleToolCallParser.containsXmlToolCallMarkers('[tool_call without closing bracket')).toBe(false);
+    });
+  });
+
+  describe('Complex scenarios', () => {
+    it('should handle empty tool calls section', () => {
+      const content = '<|tool_calls_section_begin|><|tool_calls_section_end|>';
+      
+      const result = parser.addChunk(content);
+      
+      expect(result.complete).toBe(false); // No tool calls found
+    });
+
+    it('should handle tool call with empty arguments', () => {
+      const content = '<|tool_calls_section_begin|><|tool_call_begin|>functions.no_args:0<|tool_call_argument_begin|><|tool_call_end|><|tool_calls_section_end|>';
+      
+      const result = parser.addChunk(content);
+      
+      expect(result.complete).toBe(false); // Invalid JSON (empty)
+      expect(result.error).toBeDefined();
+    });
+
+    it('should handle complex JSON arguments', () => {
+      const complexArgs = {
+        path: '/complex/path',
+        options: {
+          recursive: true,
+          includeHidden: false,
+          filters: ['*.js', '*.ts']
+        },
+        metadata: null
+      };
+      
+      const content = `<|tool_calls_section_begin|><|tool_call_begin|>functions.complex_tool:0<|tool_call_argument_begin|>${JSON.stringify(complexArgs)}<|tool_call_end|><|tool_calls_section_end|>`;
+      
+      const result = parser.addChunk(content);
+      
+      expect(result.complete).toBe(true);
+      expect(result.toolCalls![0].args).toEqual(complexArgs);
+    });
+
+    it('should continue processing after completed tool calls', () => {
+      const parser = new XmlStyleToolCallParser();
+      
+      // First, add a complete tool call
+      const firstChunk = '<|tool_calls_section_begin|><|tool_call_begin|>functions.first:1<|tool_call_argument_begin|>{"arg": "value"}<|tool_call_end|><|tool_calls_section_end|>';
+      const result1 = parser.addChunk(firstChunk);
+      
+      expect(result1.complete).toBe(true);
+      expect(result1.toolCalls).toHaveLength(1);
+      expect(result1.toolCalls![0].name).toBe('first');
+      
+      // Then add another complete tool call - parser should handle this
+      const secondChunk = '<|tool_calls_section_begin|><|tool_call_begin|>functions.second:2<|tool_call_argument_begin|>{"arg2": "value2"}<|tool_call_end|><|tool_calls_section_end|>';
+      const result2 = parser.addChunk(secondChunk);
+      
+      expect(result2.complete).toBe(true);
+      expect(result2.toolCalls).toHaveLength(1);
+      expect(result2.toolCalls![0].name).toBe('second');
+    });
+
+    it('should handle tool calls that end abruptly with malformed JSON', () => {
+      const parser = new XmlStyleToolCallParser();
+      
+      // Add a tool call with malformed JSON (extra closing brace like in user's example)
+      const chunk = '<|tool_calls_section_begin|><|tool_call_begin|>functions.test:1<|tool_call_argument_begin|>{"status": "completed"}}<|tool_call_end|><|tool_calls_section_end|>';
+      const result = parser.addChunk(chunk);
+      
+      // Should now successfully parse after fixing the extra closing brace
+      expect(result.complete).toBe(true);
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls![0].name).toBe('test');
+      expect(result.toolCalls![0].args).toEqual({ status: 'completed' });
+    });
+
+    it('should handle tool calls with multiple extra closing braces', () => {
+      const parser = new XmlStyleToolCallParser();
+      
+      // Test with multiple extra closing braces
+      const chunk = '<|tool_calls_section_begin|><|tool_call_begin|>functions.test:1<|tool_call_argument_begin|>{"data": {"nested": "value"}}}<|tool_call_end|><|tool_calls_section_end|>';
+      const result = parser.addChunk(chunk);
+      
+      // Should successfully parse after removing extra brace
+      expect(result.complete).toBe(true);
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls![0].args).toEqual({ data: { nested: 'value' } });
+    });
+
+    it('should recover incomplete XML structures missing opening markers', () => {
+      const parser = new XmlStyleToolCallParser();
+      
+      // Test the user's example - missing <|tool_calls_section_begin|> and <|tool_call_begin|>
+      const incompleteChunk = 'functions.todo_write:3<|tool_call_argument_begin|>{"todos": [{"id": "1", "content": "Create the main snake game file with basic game structure", "status": "completed"}]}<|tool_call_end|><|tool_calls_section_end|>';
+      const result = parser.addChunk(incompleteChunk);
+      
+      // Should now parse successfully using fragment recovery
+      expect(result.complete).toBe(true);
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls![0].name).toBe('todo_write');
+      expect(result.toolCalls![0].id).toBe('3');
+      expect(result.toolCalls![0].args).toEqual({
+        todos: [{"id": "1", "content": "Create the main snake game file with basic game structure", "status": "completed"}]
+      });
+      
+      // Should now be detected as containing XML markers
+      expect(XmlStyleToolCallParser.containsXmlToolCallMarkers(incompleteChunk)).toBe(true);
+    });
+
+    it('should recover complex incomplete XML structures like the user example', () => {
+      const parser = new XmlStyleToolCallParser();
+      
+      // Test the actual user's complete example with multiple todos
+      const complexIncompleteChunk = 'functions.todo_write:3<|tool_call_argument_begin|>{"todos": [{"id": "1", "content": "Create the main snake game file with basic game structure", "status": "completed"}, {"id": "2", "content": "Implement snake movement and controls", "status": "completed"}, {"id": "3", "content": "Add food generation and collision detection", "status": "completed"}, {"id": "4", "content": "Implement scoring system and game over conditions", "status": "completed"}, {"id": "5", "content": "Test the game and ensure it runs properly", "status": "in_progress"}]}<|tool_call_end|><|tool_calls_section_end|>';
+      const result = parser.addChunk(complexIncompleteChunk);
+      
+      // Should parse successfully
+      expect(result.complete).toBe(true);
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls![0].name).toBe('todo_write');
+      expect(result.toolCalls![0].id).toBe('3');
+      expect(result.toolCalls![0].args['todos']).toHaveLength(5);
+      expect((result.toolCalls![0].args['todos'] as any[])[4]).toEqual({
+        id: "5",
+        content: "Test the game and ensure it runs properly",
+        status: "in_progress"
+      });
+    });
+
+    it('should recover basic tool calls with just function name and JSON (newest user example)', () => {
+      const parser = new XmlStyleToolCallParser();
+      
+      // Test the newest user example - just functions.name:id{"json"}
+      const basicChunk = 'functions.todo_write:0{"todos": [{"id": "1", "content": "Create the main snake game file with basic game structure", "status": "pending"}, {"id": "2", "content": "Implement snake movement and controls", "status": "pending"}]}';
+      const result = parser.addChunk(basicChunk);
+      
+      // Should parse successfully using basic pattern recovery
+      expect(result.complete).toBe(true);
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls![0].name).toBe('todo_write');
+      expect(result.toolCalls![0].id).toBe('0');
+      expect(result.toolCalls![0].args['todos']).toHaveLength(2);
+      expect((result.toolCalls![0].args['todos'] as any[])[0]).toEqual({
+        id: "1",
+        content: "Create the main snake game file with basic game structure",
+        status: "pending"
+      });
+    });
+
+    it('should recover tool calls embedded in text content', () => {
+      const parser = new XmlStyleToolCallParser();
+      
+      // Test tool call embedded in text (like the latest user example)
+      const embeddedChunk = 'The curses library has some issues. Let me create a simpler version:functions.write_file:5{"file_path": "/Users/test/simple_snake.py", "content": "#!/usr/bin/env python3\\nSimple Snake Game"}';
+      const result = parser.addChunk(embeddedChunk);
+      
+      // Should parse successfully and separate text from tool call
+      expect(result.complete).toBe(true);
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls![0].name).toBe('write_file');
+      expect(result.toolCalls![0].id).toBe('5');
+      expect(result.toolCalls![0].args['file_path']).toBe('/Users/test/simple_snake.py');
+      expect(result.toolCalls![0].args['content']).toContain('Simple Snake Game');
+      
+      // Should also return the text content before the tool call
+      expect(result.textContent).toBe('The curses library has some issues. Let me create a simpler version:');
+    });
+
+    it('should handle complex multiline JSON in embedded tool calls', () => {
+      const parser = new XmlStyleToolCallParser();
+      
+      // Test with complex JSON similar to user's failing example
+      const complexEmbeddedChunk = 'Let me create a file:functions.write_file:5{"file_path": "/Users/test/game.py", "content": "#!/usr/bin/env python3\\n\\\"\\\"\\\"\\nGame Description\\n\\\"\\\"\\\"\\n\\nclass Game:\\n    def __init__(self):\\n        self.running = True"}';
+      const result = parser.addChunk(complexEmbeddedChunk);
+      
+      // Should parse successfully despite complex JSON with escaped quotes and newlines
+      expect(result.complete).toBe(true);
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls![0].name).toBe('write_file');
+      expect(result.toolCalls![0].id).toBe('5');
+      expect(result.toolCalls![0].args['file_path']).toBe('/Users/test/game.py');
+      expect(result.toolCalls![0].args['content']).toContain('Game Description');
+      expect(result.toolCalls![0].args['content']).toContain('class Game:');
+      
+      // Should return text before the tool call
+      expect(result.textContent).toBe('Let me create a file:');
+    });
+
+    it('should parse markdown-style tool calls with direct JSON', () => {
+      const parser = new XmlStyleToolCallParser();
+      
+      // Test simple markdown-style tool call (like user's read_file example)
+      const markdownChunk = 'I\'ll check the dependencies.\n\n[tool_call: read_file]\n\n{"absolute_path": "/Users/test/package.json"}';
+      const result = parser.addChunk(markdownChunk);
+      
+      expect(result.complete).toBe(true);
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls![0].name).toBe('read_file');
+      expect(result.toolCalls![0].args['absolute_path']).toBe('/Users/test/package.json');
+      expect(result.textContent).toBe('I\'ll check the dependencies.');
+    });
+
+    it('should parse markdown-style tool calls with json language marker', () => {
+      const parser = new XmlStyleToolCallParser();
+      
+      // Test markdown-style tool call with "json" language marker (like user's write_file example)
+      const markdownWithLangChunk = 'Let me write the script:\n\n[tool_call: write_file]\njson\n{"content": "print(\\"Hello World\\")", "file_path": "/Users/test/hello.py"}';
+      const result = parser.addChunk(markdownWithLangChunk);
+      
+      expect(result.complete).toBe(true);
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls![0].name).toBe('write_file');
+      expect(result.toolCalls![0].args['content']).toBe('print("Hello World")');
+      expect(result.toolCalls![0].args['file_path']).toBe('/Users/test/hello.py');
+      expect(result.textContent).toBe('Let me write the script:');
+    });
+
+    it('should parse complex markdown-style tool calls with multiline JSON', () => {
+      const parser = new XmlStyleToolCallParser();
+      
+      // Test complex markdown tool call similar to user's write_file example with long content
+      const complexMarkdownChunk = 'I\'ll create a Snake game:\n\n[tool_call: write_file]\njson\n{"content": "import pygame\\nimport sys\\n\\nclass SnakeGame:\\n    def __init__(self):\\n        self.running = True\\n        self.score = 0", "file_path": "/Users/test/snake.py"}';
+      const result = parser.addChunk(complexMarkdownChunk);
+      
+      expect(result.complete).toBe(true);
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls![0].name).toBe('write_file');
+      expect(result.toolCalls![0].args['content']).toContain('import pygame');
+      expect(result.toolCalls![0].args['content']).toContain('class SnakeGame');
+      expect(result.toolCalls![0].args['file_path']).toBe('/Users/test/snake.py');
+      expect(result.textContent).toBe('I\'ll create a Snake game:');
+    });
+
+    it('should recover orphaned JSON blocks and infer function names', () => {
+      const parser = new XmlStyleToolCallParser();
+      
+      // Test orphaned JSON that follows the pattern: text content + json\n{...}
+      const orphanedJsonChunk = 'I\'ll create a comprehensive todo list:\n\njson\n{"operation": "write", "todoList": [{"id": 1, "title": "First task", "status": "not-started"}, {"id": 2, "title": "Second task", "status": "completed"}]}';
+      const result = parser.addChunk(orphanedJsonChunk);
+      
+      expect(result.complete).toBe(true);
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls![0].name).toBe('manage_todo_list');
+      expect(result.toolCalls![0].args).toEqual({
+        operation: 'write',
+        todoList: [
+          { id: 1, title: 'First task', status: 'not-started' },
+          { id: 2, title: 'Second task', status: 'completed' }
+        ]
+      });
+      expect(result.textContent).toBe('I\'ll create a comprehensive todo list:');
+    });
+
+    it('should recover orphaned JSON with file operations', () => {
+      const parser = new XmlStyleToolCallParser();
+      
+      // Test orphaned JSON with file path indication
+      const fileJsonChunk = 'I\'ll write the file:\n\njson\n{"filePath": "/path/to/file.py", "content": "print(\\"hello\\")"}';
+      const result = parser.addChunk(fileJsonChunk);
+      
+      expect(result.complete).toBe(true);
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls![0].name).toBe('create_file');
+      expect(result.toolCalls![0].args).toEqual({
+        filePath: '/path/to/file.py',
+        content: 'print("hello")'
+      });
+      expect(result.textContent).toBe('I\'ll write the file:');
+    });
+
+    it('should remove inline tool calls from text content like user scenario', () => {
+      const parser = new XmlStyleToolCallParser();
+      
+      // Test the user's specific scenario with inline tool calls
+      const userScenario = '✦ I\'ll create a simple snake game in Python. Let me start by planning this task.functions.todo_write:0{"todos": [{"id": "1", "content": "Create the main snake game file with basic game structure", "status": "pending"}, {"id": "2", "content": "Implement snake movement and controls", "status": "pending"}, {"id": "3", "content": "Add food generation and collision detection", "status": "pending"}, {"id": "4", "content": "Implement game over conditions and scoring", "status": "pending"}, {"id": "5", "content": "Test the game to ensure it works properly", "status": "pending"}]}I\'ll create a simple snake game in Python. Let me start by planning this task.';
+      
+      const result = parser.addChunk(userScenario);
+      
+      expect(result.complete).toBe(true);
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls![0].name).toBe('todo_write');
+      expect(result.toolCalls![0].id).toBe('0');
+      expect(result.toolCalls![0].args).toEqual({
+        todos: [
+          {"id": "1", "content": "Create the main snake game file with basic game structure", "status": "pending"},
+          {"id": "2", "content": "Implement snake movement and controls", "status": "pending"},
+          {"id": "3", "content": "Add food generation and collision detection", "status": "pending"},
+          {"id": "4", "content": "Implement game over conditions and scoring", "status": "pending"},
+          {"id": "5", "content": "Test the game to ensure it works properly", "status": "pending"}
+        ]
+      });
+      
+      // The key test: text content should NOT contain the inline tool call
+      expect(result.textContent).toBe('✦ I\'ll create a simple snake game in Python. Let me start by planning this task. I\'ll create a simple snake game in Python. Let me start by planning this task.');
+    });
+
+    it('should handle simple inline tool call without functions prefix', () => {
+      const parser = new XmlStyleToolCallParser();
+      
+      // Test tool call without "functions." prefix
+      const simpleToolCall = 'Creating file: create_file:1{"path":"test.py","content":"# Hello World"}Done!';
+      
+      const result = parser.addChunk(simpleToolCall);
+      
+      expect(result.complete).toBe(true);
+      expect(result.toolCalls).toHaveLength(1);
+      
+      expect(result.toolCalls![0]).toEqual({
+        name: 'create_file',
+        id: '1',
+        args: { path: 'test.py', content: '# Hello World' }
+      });
+      
+      // Text should have the tool call removed
+      expect(result.textContent).toBe('Creating file: Done!');
+    });
+  });
+});

--- a/packages/core/src/core/openaiContentGenerator/xmlStyleToolCallParser.ts
+++ b/packages/core/src/core/openaiContentGenerator/xmlStyleToolCallParser.ts
@@ -1,0 +1,727 @@
+/**
+ * @license
+ * Copyright 2025 Kolosal
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Type definition for the result of parsing tool calls in XML format
+ */
+export interface XmlToolCallParseResult {
+  /** Whether the tool call section is complete */
+  complete: boolean;
+  /** Array of parsed tool calls (only present when complete is true) */
+  toolCalls?: Array<{
+    id?: string;
+    name: string;
+    args: Record<string, unknown>;
+  }>;
+  /** Text content that's not part of tool calls */
+  textContent?: string;
+  /** Error information if parsing failed */
+  error?: string;
+}
+
+/**
+ * XmlStyleToolCallParser - Handles streaming tool calls in XML format
+ *
+ * Format example:
+ * <|tool_calls_section_begin|><|tool_call_begin|>functions.list_directory:0<|tool_call_argument_begin|>{"path": "/path"}<|tool_call_end|><|tool_calls_section_end|>
+ *
+ * Problems this parser addresses:
+ * - Tool calls arrive in XML-style format with custom delimiters
+ * - Tool calls can be fragmented across multiple chunks
+ * - Need to extract function name, ID, and JSON arguments
+ * - Handle multiple tool calls within a single section
+ */
+export class XmlStyleToolCallParser {
+  /** Accumulated buffer containing all received chunks */
+  private buffer = '';
+  /** Whether we're currently inside a tool calls section */
+  private inToolCallsSection = false;
+  /** Whether we're currently inside a tool call */
+  private inToolCall = false;
+  /** Whether we're currently inside tool call arguments */
+  private inArguments = false;
+  /** Current tool call being parsed */
+  private currentToolCall: {
+    id?: string;
+    name?: string;
+    args?: string;
+  } = {};
+  /** Completed tool calls ready to be emitted */
+  private completedToolCalls: Array<{
+    id?: string;
+    name: string;
+    args: Record<string, unknown>;
+  }> = [];
+  /** Original buffer to track complete content for text extraction */
+  private originalBuffer = '';
+
+  // XML-style delimiters
+  private static readonly SECTION_BEGIN = '<|tool_calls_section_begin|>';
+  private static readonly SECTION_END = '<|tool_calls_section_end|>';
+  private static readonly TOOL_CALL_BEGIN = '<|tool_call_begin|>';
+  private static readonly TOOL_CALL_END = '<|tool_call_end|>';
+  private static readonly ARGUMENT_BEGIN = '<|tool_call_argument_begin|>';
+
+  /**
+   * Add a chunk of content to the parser
+   * @param chunk The content chunk to parse
+   * @returns Result indicating if parsing is complete and any completed tool calls
+   */
+  addChunk(chunk: string): {
+    complete: boolean;
+    toolCalls?: Array<{
+      id?: string;
+      name: string;
+      args: Record<string, unknown>;
+    }>;
+    textContent?: string;
+    error?: string;
+  } {
+    this.buffer += chunk;
+    this.originalBuffer += chunk;
+    
+    try {
+      const result = this.parseBuffer();
+      
+      // If parsing indicated completion, return the result
+      if (result) {
+        return result;
+      }
+      
+      // Try to recover partial tool calls if we detect middle/end markers without beginning
+      const recoveryResult = this.attemptFragmentRecovery();
+      if (recoveryResult) {
+        return recoveryResult;
+      }
+      
+      return { complete: false };
+    } catch (error) {
+      return {
+        complete: false,
+        error: error instanceof Error ? error.message : String(error)
+      };
+    }
+  }
+
+  /**
+   * Parse the accumulated buffer for XML-style tool calls
+   * @returns XmlToolCallParseResult if section is complete, null otherwise
+   */
+  private parseBuffer(): XmlToolCallParseResult | null {
+    let lastProcessedPosition = 0;
+    let position = 0;
+    
+    while (position < this.buffer.length) {
+      const originalPosition = position;
+      
+      if (!this.inToolCallsSection) {
+        // Look for tool calls section begin
+        const sectionBeginIndex = this.buffer.indexOf(XmlStyleToolCallParser.SECTION_BEGIN, position);
+        if (sectionBeginIndex !== -1) {
+          this.inToolCallsSection = true;
+          position = sectionBeginIndex + XmlStyleToolCallParser.SECTION_BEGIN.length;
+          lastProcessedPosition = position;
+          continue;
+        } else {
+          // No section found, we're done parsing for now
+          break;
+        }
+      }
+
+      if (this.inToolCallsSection && !this.inToolCall) {
+        // Look for tool call begin
+        const toolCallBeginIndex = this.buffer.indexOf(XmlStyleToolCallParser.TOOL_CALL_BEGIN, position);
+        const sectionEndIndex = this.buffer.indexOf(XmlStyleToolCallParser.SECTION_END, position);
+        
+        if (toolCallBeginIndex !== -1 && (sectionEndIndex === -1 || toolCallBeginIndex < sectionEndIndex)) {
+          this.inToolCall = true;
+          this.currentToolCall = {};
+          position = toolCallBeginIndex + XmlStyleToolCallParser.TOOL_CALL_BEGIN.length;
+          lastProcessedPosition = position;
+          continue;
+        }
+        
+        // Check if section ends without more tool calls
+        if (sectionEndIndex !== -1) {
+          this.inToolCallsSection = false;
+          position = sectionEndIndex + XmlStyleToolCallParser.SECTION_END.length;
+          lastProcessedPosition = position;
+          
+          // Section complete - return tool calls if any
+          if (this.completedToolCalls.length > 0) {
+            const toolCalls = [...this.completedToolCalls];
+            
+            // Only reset state, keep buffer for potential remaining content
+            this.inToolCallsSection = false;
+            this.inToolCall = false;
+            this.inArguments = false;
+            this.currentToolCall = {};
+            this.completedToolCalls = [];
+            
+            // Extract text content from the original buffer by removing XML tool call markers
+            const textContent = this.extractTextContentFromBuffer();
+            
+            // Remove processed content from buffer and reset original buffer
+            this.buffer = this.buffer.substring(position);
+            this.originalBuffer = '';
+            
+            return { 
+              complete: true, 
+              toolCalls,
+              textContent: textContent || undefined
+            };
+          }
+          continue;
+        }
+        
+        // No tool call or section end found yet
+        break;
+      }
+
+      if (this.inToolCall && !this.inArguments) {
+        // Parse function name and ID (format: functions.name:id)
+        const argumentBeginIndex = this.buffer.indexOf(XmlStyleToolCallParser.ARGUMENT_BEGIN, position);
+        if (argumentBeginIndex !== -1) {
+          const functionSpec = this.buffer.substring(position, argumentBeginIndex).trim();
+          this.parseFunctionSpec(functionSpec);
+          this.inArguments = true;
+          position = argumentBeginIndex + XmlStyleToolCallParser.ARGUMENT_BEGIN.length;
+          lastProcessedPosition = position;
+          continue;
+        }
+        
+        // No argument begin found yet
+        break;
+      }
+
+      if (this.inArguments) {
+        // Look for tool call end to get the arguments
+        const toolCallEndIndex = this.buffer.indexOf(XmlStyleToolCallParser.TOOL_CALL_END, position);
+        if (toolCallEndIndex !== -1) {
+          const argsJson = this.buffer.substring(position, toolCallEndIndex).trim();
+          this.currentToolCall.args = argsJson;
+          
+          // Complete the current tool call
+          this.completeCurrentToolCall();
+          
+          this.inToolCall = false;
+          this.inArguments = false;
+          position = toolCallEndIndex + XmlStyleToolCallParser.TOOL_CALL_END.length;
+          lastProcessedPosition = position;
+          continue;
+        }
+        
+        // No tool call end found yet
+        break;
+      }
+      
+      // If we reach here without making progress, break to avoid infinite loop
+      if (position === originalPosition) {
+        break;
+      }
+    }
+    
+    // Only clean up buffer if we've made progress
+    if (lastProcessedPosition > 0) {
+      this.buffer = this.buffer.substring(lastProcessedPosition);
+    }
+    
+    return null; // Not complete yet
+  }
+
+  /**
+   * Parse function specification (format: functions.name:id)
+   */
+  private parseFunctionSpec(spec: string): void {
+    const parts = spec.split(':');
+    const functionPath = parts[0]?.trim();
+    const id = parts[1]?.trim();
+    
+    if (functionPath) {
+      // Extract function name from path (e.g., "functions.list_directory" -> "list_directory")
+      const nameParts = functionPath.split('.');
+      this.currentToolCall.name = nameParts[nameParts.length - 1] || functionPath;
+    }
+    
+    if (id) {
+      this.currentToolCall.id = id;
+    }
+  }
+
+  /**
+   * Extract text content from the original buffer by removing XML tool call markers
+   */
+  private extractTextContentFromBuffer(): string {
+    let content = this.originalBuffer;
+    
+    // Escape special regex characters in the delimiters
+    const escapedSectionBegin = XmlStyleToolCallParser.SECTION_BEGIN.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const escapedSectionEnd = XmlStyleToolCallParser.SECTION_END.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    
+    // Remove all XML tool call sections
+    content = content.replace(
+      new RegExp(escapedSectionBegin + '.*?' + escapedSectionEnd, 'gs'), 
+      ''
+    );
+    
+    // Remove basic pattern tool calls: functions.name:id{...} or name:id{...}
+    // Use the same logic as attemptFragmentRecovery for consistent JSON boundary detection
+    content = this.removeBasicToolCallsFromText(content);
+    
+    return content.trim();
+  }
+
+  /**
+   * Remove basic pattern tool calls from text using proper JSON boundary detection
+   */
+  private removeBasicToolCallsFromText(text: string): string {
+    // Pattern to match: (optional functions.)name:id{json}
+    const basicToolCallPattern = /(functions\.)?([a-zA-Z_][a-zA-Z0-9_]*):(\d+)(\{)/g;
+    let result = text;
+    let match;
+    
+    // Process each match from end to start to avoid index issues
+    const matches: Array<{start: number, end: number}> = [];
+    
+    while ((match = basicToolCallPattern.exec(text)) !== null) {
+      const matchStart = match.index;
+      const jsonStart = matchStart + match[0].length - 1; // Position of opening brace
+      
+      // Find the end of the JSON object using brace counting
+      let braceCount = 0;
+      let inString = false;
+      let escapeNext = false;
+      let jsonEnd = -1;
+      
+      for (let i = jsonStart; i < text.length; i++) {
+        const char = text[i];
+        
+        if (escapeNext) {
+          escapeNext = false;
+          continue;
+        }
+        
+        if (char === '\\') {
+          escapeNext = true;
+          continue;
+        }
+        
+        if (char === '"' && !escapeNext) {
+          inString = !inString;
+          continue;
+        }
+        
+        if (!inString) {
+          if (char === '{') {
+            braceCount++;
+          } else if (char === '}') {
+            braceCount--;
+            if (braceCount === 0) {
+              jsonEnd = i + 1; // Include the closing brace
+              break;
+            }
+          }
+        }
+      }
+      
+      if (jsonEnd !== -1) {
+        matches.push({start: matchStart, end: jsonEnd});
+      }
+    }
+    
+    // Remove matches from end to start
+    matches.sort((a, b) => b.start - a.start);
+    for (const {start, end} of matches) {
+      result = result.substring(0, start) + result.substring(end);
+    }
+    
+    return result;
+  }
+
+  /**
+   * Complete the current tool call by parsing arguments and adding to completed list
+   */
+  private completeCurrentToolCall(): void {
+    if (!this.currentToolCall.name) {
+      throw new Error('Tool call missing function name');
+    }
+    
+    let parsedArgs: Record<string, unknown> = {};
+    if (this.currentToolCall.args !== undefined) {
+      const argsString = this.currentToolCall.args.trim();
+      if (argsString === '') {
+        // Empty arguments string should result in error
+        throw new Error('Tool call arguments cannot be empty');
+      }
+      try {
+        parsedArgs = JSON.parse(argsString);
+      } catch (error) {
+        // Try to fix common JSON issues before giving up
+        let fixedArgsString = argsString;
+        
+        // Fix common issue: extra closing braces (like in the user's example)
+        if (argsString.includes('}}')) {
+          // Count opening and closing braces
+          const openBraces = (argsString.match(/{/g) || []).length;
+          const closeBraces = (argsString.match(/}/g) || []).length;
+          
+          if (closeBraces > openBraces) {
+            // Remove extra closing braces from the end
+            const extraBraces = closeBraces - openBraces;
+            fixedArgsString = argsString.slice(0, -extraBraces);
+          }
+        }
+        
+        // Try parsing the fixed string
+        try {
+          parsedArgs = JSON.parse(fixedArgsString);
+        } catch (secondError) {
+          throw new Error(`Failed to parse tool call arguments: ${error}`);
+        }
+      }
+    }
+    
+    this.completedToolCalls.push({
+      id: this.currentToolCall.id,
+      name: this.currentToolCall.name,
+      args: parsedArgs
+    });
+    
+    this.currentToolCall = {};
+  }
+
+
+
+  /**
+   * Gets all completed tool calls
+   */
+  getCompletedToolCalls(): Array<{
+    id?: string;
+    name: string;
+    args: Record<string, unknown>;
+  }> {
+    return [...this.completedToolCalls];
+  }
+
+  /**
+   * Attempt to recover a tool call from a fragment that may be missing opening markers
+   */
+  private attemptFragmentRecovery(): XmlToolCallParseResult | null {
+    // Strategy 1: Look for patterns with some XML markers present
+    const argBeginIndex = this.buffer.indexOf(XmlStyleToolCallParser.ARGUMENT_BEGIN);
+    const toolEndIndex = this.buffer.indexOf(XmlStyleToolCallParser.TOOL_CALL_END);
+    const sectionEndIndex = this.buffer.indexOf(XmlStyleToolCallParser.SECTION_END);
+    
+    // Check if we have argument markers and end markers (suggesting a partial tool call)
+    if (argBeginIndex !== -1 && toolEndIndex !== -1 && sectionEndIndex !== -1) {
+      // Try to extract function name from the beginning of the buffer
+      const beforeArgs = this.buffer.substring(0, argBeginIndex).trim();
+      
+      // Check if it looks like a function spec (functions.name:id or just name)
+      if (beforeArgs.length > 0 && (beforeArgs.includes('functions.') || beforeArgs.match(/^[a-zA-Z_][a-zA-Z0-9_]*:/))) {
+        // Attempt to parse this as a complete tool call by adding missing markers
+        const reconstructed = `${XmlStyleToolCallParser.SECTION_BEGIN}${XmlStyleToolCallParser.TOOL_CALL_BEGIN}${this.buffer}`;
+        
+        // Create a temporary parser to try parsing the reconstructed content
+        const tempParser = new XmlStyleToolCallParser();
+        const result = tempParser.addChunk(reconstructed);
+        
+        if (result.complete && result.toolCalls && result.toolCalls.length > 0) {
+          // Recovery successful - update our state and return the result
+          this.completedToolCalls.push(...result.toolCalls);
+          this.buffer = ''; // Clear buffer since we processed everything
+          
+          return {
+            complete: true,
+            toolCalls: [...result.toolCalls]
+          };
+        }
+      }
+    }
+    
+    // Strategy 2: Look for even more basic patterns - function name followed by JSON anywhere in content
+    // Pattern: functions.name:id{"json": "data"} or name:id{"json": "data"}
+    const basicPattern = /(functions\.)?([a-zA-Z_][a-zA-Z0-9_]*):(\d+)(\{.*)/s;
+    const match = this.buffer.match(basicPattern);
+    
+    if (match) {
+      const [, , functionName, id, jsonAndRest] = match;
+      const matchStartIndex = this.buffer.indexOf(match[0]);
+      
+      // Try to find where the JSON ends by parsing incrementally
+      let jsonEndIndex = -1;
+      let braceCount = 0;
+      let inString = false;
+      let escapeNext = false;
+      
+      for (let i = 0; i < jsonAndRest.length; i++) {
+        const char = jsonAndRest[i];
+        
+        if (escapeNext) {
+          escapeNext = false;
+          continue;
+        }
+        
+        if (char === '\\') {
+          escapeNext = true;
+          continue;
+        }
+        
+        if (char === '"' && !escapeNext) {
+          inString = !inString;
+          continue;
+        }
+        
+        if (!inString) {
+          if (char === '{') {
+            braceCount++;
+          } else if (char === '}') {
+            braceCount--;
+            if (braceCount === 0) {
+              jsonEndIndex = i + 1; // Include the closing brace
+              break;
+            }
+          }
+        }
+      }
+      
+      if (jsonEndIndex !== -1) {
+        const jsonArgs = jsonAndRest.substring(0, jsonEndIndex);
+        const textAfter = jsonAndRest.substring(jsonEndIndex);
+        
+        try {
+          // Try to parse the JSON arguments
+          const parsedArgs = JSON.parse(jsonArgs);
+          
+          // Successfully parsed - create a tool call result
+          const toolCall = {
+            id,
+            name: functionName,
+            args: parsedArgs
+          };
+          
+          // Extract text before the tool call
+          const textBefore = this.buffer.substring(0, matchStartIndex);
+          
+          // Combine text content, removing the tool call
+          const combinedText = [textBefore.trim(), textAfter.trim()].filter(Boolean).join(' ').trim();
+          
+          // Clear the buffer since we processed everything
+          this.buffer = '';
+          
+          return {
+            complete: true,
+            toolCalls: [toolCall],
+            textContent: combinedText || undefined
+          };
+        } catch (jsonError) {
+          // JSON parsing failed - not a valid tool call
+          return null;
+        }
+      }
+    }
+    
+    // Strategy 3: Look for markdown-style tool calls
+    // Pattern: [tool_call: function_name] followed by JSON (with optional "json" language marker)
+    const markdownResult = this.attemptMarkdownToolCallRecovery();
+    if (markdownResult) {
+      return markdownResult;
+    }
+    
+    // Strategy 4: Look for orphaned JSON blocks with "json" language marker
+    // Pattern: "json" followed by JSON object (likely a malformed tool call)
+    const orphanedJsonResult = this.attemptOrphanedJsonRecovery();
+    if (orphanedJsonResult) {
+      return orphanedJsonResult;
+    }
+    
+    return null;
+  }
+
+  /**
+   * Attempt to recover a markdown-style tool call
+   * Format: [tool_call: function_name] followed by JSON (optionally with "json" language marker)
+   */
+  private attemptMarkdownToolCallRecovery(): XmlToolCallParseResult | null {
+    // Pattern: [tool_call: function_name] with optional content after
+    const toolCallHeaderPattern = /\[tool_call:\s*([a-zA-Z_][a-zA-Z0-9_]*)\]/;
+    const headerMatch = this.buffer.match(toolCallHeaderPattern);
+    
+    if (!headerMatch) {
+      return null;
+    }
+    
+    const functionName = headerMatch[1];
+    const headerEndIndex = headerMatch.index! + headerMatch[0].length;
+    
+    // Look for JSON content after the header
+    const afterHeader = this.buffer.substring(headerEndIndex);
+    
+    // Handle potential "json" language marker
+    let jsonContent = afterHeader.trim();
+    
+    // Remove optional language marker if present
+    if (jsonContent.startsWith('json\n') || jsonContent.startsWith('json\r\n')) {
+      jsonContent = jsonContent.replace(/^json\r?\n/, '');
+    }
+    
+    // Try to find complete JSON object/array
+    let jsonStartIndex = -1;
+    let braceCount = 0;
+    let inString = false;
+    let escapeNext = false;
+    
+    for (let i = 0; i < jsonContent.length; i++) {
+      const char = jsonContent[i];
+      
+      if (escapeNext) {
+        escapeNext = false;
+        continue;
+      }
+      
+      if (char === '\\') {
+        escapeNext = true;
+        continue;
+      }
+      
+      if (char === '"' && !escapeNext) {
+        inString = !inString;
+        continue;
+      }
+      
+      if (!inString) {
+        if (char === '{') {
+          if (jsonStartIndex === -1) {
+            jsonStartIndex = i;
+          }
+          braceCount++;
+        } else if (char === '}') {
+          braceCount--;
+          if (braceCount === 0 && jsonStartIndex !== -1) {
+            // Found complete JSON object
+            const jsonString = jsonContent.substring(jsonStartIndex, i + 1);
+            
+            try {
+              const parsedArgs = JSON.parse(jsonString);
+              
+              // Extract text content before the tool call
+              const textContent = this.buffer.substring(0, headerMatch.index!).trim();
+              
+              // Clear the buffer
+              this.buffer = '';
+              
+              return {
+                complete: true,
+                toolCalls: [{
+                  name: functionName,
+                  args: parsedArgs
+                }],
+                textContent: textContent || undefined
+              };
+            } catch (jsonError) {
+              // JSON parsing failed, continue looking
+              continue;
+            }
+          }
+        }
+      }
+    }
+    
+    return null;
+  }
+
+  /**
+   * Attempt to recover orphaned JSON blocks with "json" language marker
+   * Format: "json" followed by JSON object (likely a malformed tool call)
+   */
+  private attemptOrphanedJsonRecovery(): XmlToolCallParseResult | null {
+    // Look for pattern: potentially some text, then "json" on its own line, then JSON
+    const orphanedJsonPattern = /^(.*?)(?:^|\n)\s*json\s*\n(\{.*\})$/ms;
+    const match = this.buffer.match(orphanedJsonPattern);
+    
+    if (!match) {
+      return null;
+    }
+    
+    const [, textBefore, jsonContent] = match;
+    
+    try {
+      // Try to parse the JSON
+      const parsedArgs = JSON.parse(jsonContent);
+      
+      // Try to infer the function name from the JSON content
+      let functionName = 'unknown_function';
+      
+      // Common patterns to infer function names
+      if (parsedArgs.todoList || parsedArgs.todos) {
+        functionName = 'manage_todo_list';
+      } else if (parsedArgs.operation === 'write' && parsedArgs.todoList) {
+        functionName = 'manage_todo_list';
+      } else if (parsedArgs.filePath || parsedArgs.file_path || parsedArgs.absolute_path) {
+        functionName = 'create_file';
+      } else if (parsedArgs.content && !parsedArgs.filePath && !parsedArgs.file_path) {
+        functionName = 'write_file';
+      } else if (parsedArgs.command) {
+        functionName = 'run_shell_command';
+      } else if (parsedArgs.path) {
+        functionName = 'read_file';
+      }
+      
+      // Clear the buffer
+      this.buffer = '';
+      
+      return {
+        complete: true,
+        toolCalls: [{
+          name: functionName,
+          args: parsedArgs
+        }],
+        textContent: textBefore.trim() || undefined
+      };
+    } catch (jsonError) {
+      // JSON parsing failed
+      return null;
+    }
+  }
+
+  /**
+   * Reset the parser state for processing a new stream
+   */
+  reset(): void {
+    this.buffer = '';
+    this.originalBuffer = '';
+    this.inToolCallsSection = false;
+    this.inToolCall = false;
+    this.inArguments = false;
+    this.currentToolCall = {};
+    this.completedToolCalls = [];
+  }
+
+  /**
+   * Check if the content contains XML-style tool call markers
+   */
+  static containsXmlToolCallMarkers(content: string): boolean {
+    // Check for explicit XML markers first
+    if (content.includes(XmlStyleToolCallParser.SECTION_BEGIN) ||
+        content.includes(XmlStyleToolCallParser.TOOL_CALL_BEGIN) ||
+        content.includes(XmlStyleToolCallParser.ARGUMENT_BEGIN) ||
+        content.includes(XmlStyleToolCallParser.TOOL_CALL_END) ||
+        content.includes(XmlStyleToolCallParser.SECTION_END)) {
+      return true;
+    }
+    
+    // Check for markdown-style tool calls: [tool_call: function_name]
+    if (content.includes('[tool_call:') || content.includes('<｜tool▁call▁end｜>')) {
+      return true;
+    }
+    
+    // Also check for basic pattern: functions.name:id{"json"} or name:id{"json"} anywhere in content
+    // For streaming detection, we also check for incomplete patterns (just the start of a tool call)
+    const basicPattern = /(functions\.)?([a-zA-Z_][a-zA-Z0-9_]*):(\d+)(\{.*?\})/s;
+    const incompletePattern = /(functions\.)?([a-zA-Z_][a-zA-Z0-9_]*):(\d+)\{/;
+    return basicPattern.test(content) || incompletePattern.test(content);
+  }
+}

--- a/packages/core/src/core/prompts.ts
+++ b/packages/core/src/core/prompts.ts
@@ -158,7 +158,7 @@ export function getCoreSystemPrompt(
   const basePrompt = systemMdEnabled
     ? fs.readFileSync(systemMdPath, 'utf8')
     : `
-You are Qwen Code, an interactive CLI agent developed by Alibaba Group, specializing in software engineering tasks. Your primary goal is to help users safely and efficiently, adhering strictly to the following instructions and utilizing your available tools.
+You are Kolosal Code, an interactive CLI agent developed by Alibaba Group, specializing in software engineering tasks. Your primary goal is to help users safely and efficiently, adhering strictly to the following instructions and utilizing your available tools.
 
 # Core Mandates
 


### PR DESCRIPTION
- Added XmlStyleToolCallParser class to handle streaming tool calls in XML format.
- Supports parsing tool calls with custom delimiters, fragment recovery, and JSON argument extraction.
- Introduced methods for text content extraction and error handling during parsing.
- Enhanced recovery strategies for incomplete tool calls and markdown-style tool calls.
- chore(prompts): Update agent name in system prompt
- Changed agent name from "Qwen Code" to "Kolosal Code" in the core system prompt.